### PR TITLE
Fix tweakers.net selector string

### DIFF
--- a/AdSniper.js
+++ b/AdSniper.js
@@ -16,7 +16,7 @@
         switch (window.location.host)
         {
             case 'frontpage.fok.nl' : return 'div[class*="desktop-billboard"]';
-            case 'tweakers.net'     : return 'div[class*="billBoard"], div[class*="halfPage"], div[class*="leaderBoard"], div[class*="originalReplacementBannerStyle"';
+            case 'tweakers.net'     : return 'div[class*="billBoard"], div[class*="halfPage"], div[class*="leaderBoard"], div[class*="originalReplacementBannerStyle"]';
             case 'www.nu.nl'        : return 'div[id="header"], iframe[id*="pexi"], iframe[id*="utif"], div[id*="r1"]';
             default                 : return null;
         }


### PR DESCRIPTION
## Summary
- fix missing closing characters in the selector string for `tweakers.net`

## Testing
- `node -e "require('./AdSniper.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683f5089b108832798d2eba091c99e62